### PR TITLE
Fix for NordLynx mode

### DIFF
--- a/schemas/org.gnome.shell.extensions.nvpnconnect.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.nvpnconnect.gschema.xml
@@ -43,7 +43,7 @@
             <default>"systemctl is-active nordvpnd | grep -Eo '^active$'"</default>
         </key>
         <key type="s" name="cmd-vpn-online-check">
-            <default>"ifconfig -a | grep tun0"</default>
+            <default>"ifconfig -a | egrep  '(nordvpn|tun0)'"</default>
         </key>
         <key type="s" name="cmd-option-set">
             <default>"nordvpn set _%option%_ _%value%_"</default>

--- a/schemas/org.gnome.shell.extensions.nvpnconnect.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.nvpnconnect.gschema.xml
@@ -43,7 +43,7 @@
             <default>"systemctl is-active nordvpnd | grep -Eo '^active$'"</default>
         </key>
         <key type="s" name="cmd-vpn-online-check">
-            <default>"ifconfig -a | egrep  '(nordvpn|tun0)'"</default>
+            <default>"ifconfig -a | grep -E '(nordvpn|tun0)'"</default>
         </key>
         <key type="s" name="cmd-option-set">
             <default>"nordvpn set _%option%_ _%value%_"</default>


### PR DESCRIPTION
NordLynx mode never showed up as connected because the default command only checked for a tunnel (tun0) device. NordLynx protocol is basically WireGuard and is a network device with nordvpn prefix.
This regex works for both NordLynx protocol and otherwise.

Thank you for creating the extension :)