### PR TITLE
Switch vpn tech string from "nordvpn" to "nordlynx"

### DIFF
--- a/schemas/org.gnome.shell.extensions.nvpnconnect.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.nvpnconnect.gschema.xml
@@ -48,7 +48,7 @@
             <default>"systemctl is-active nordvpnd | grep -Eo '^active$'"</default>
         </key>
         <key type="s" name="cmd-vpn-online-check">
-            <default>"ifconfig -a | grep -E '(nordvpn|tun0)'"</default>
+            <default>"ifconfig -a | grep -E '(nordlynx|tun0)'"</default>
         </key>
         <key type="s" name="cmd-option-set">
             <default>"nordvpn set _%option%_ _%value%_"</default>


### PR DESCRIPTION
Update the pattern that's grepped to determine whether the vpn is online to use `nordlynx` rather than `nordvpn` to reflect the options in newer versions of NordVPN.

Closes #18 